### PR TITLE
EL-2291: Link Session Data to V2 routes in Prototype Kit

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -8,3 +8,4 @@ const router = govukPrototypeKit.requests.setupRouter()
 
 // Add your routes here
 require('./routes/v1.js')
+require('./routes/v2.js')


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2291)

**WHAT**

- add `require('./routes/v2.js')` to `app/routes.js`

**WHY**

- To get session data into V2 of routes